### PR TITLE
fix valid_url?/1 backtracking that accepted invalid trailing TLDs

### DIFF
--- a/lib/funkspector/utils.ex
+++ b/lib/funkspector/utils.ex
@@ -6,7 +6,7 @@ defmodule Funkspector.Utils do
   and URL validation using a regular expression that supports internationalized domain names.
   """
 
-  @url_regexp ~r/\Ahttp(s?)\:\/\/[a-zñäëïöüáéíóúàèìòùâêîôû0-9\-_]+([\.]{1}[a-zñäëïöüáéíóúàèìòùâêîôû0-9\-]+)*\.[a-z0-9]{2,5}(([0-9]{1,5})?(:(\d{1,5}))?\/?.*)?\z/i
+  @url_regexp ~r/\Ahttp(s?)\:\/\/[a-zñäëïöüáéíóúàèìòùâêîôû0-9\-_]+([\.]{1}[a-zñäëïöüáéíóúàèìòùâêîôû0-9\-]+)*\.[a-z0-9]{2,5}(([0-9]{1,5})?(:(\d{1,5}))?([\/\?#].*)?)?\z/i
 
   @doc """
   Converts relative URLs to absolute URLs using the given base URL.

--- a/test/utils_test.exs
+++ b/test/utils_test.exs
@@ -84,6 +84,12 @@ defmodule UtilsTest do
       refute Utils.valid_url?("https://example.ññ")
     end
 
+    test "returns false when a valid TLD is followed by invalid trailing segments" do
+      refute Utils.valid_url?("https://example.com.ñ")
+      refute Utils.valid_url?("https://example.com.ññ")
+      refute Utils.valid_url?("https://example.abcdef")
+    end
+
     test "returns false for non-HTTP URLs" do
       refute Utils.valid_url?("ftp://example.com")
       refute Utils.valid_url?("mailto:user@example.com")


### PR DESCRIPTION
The trailing `\/?.*` in @url_regexp let `.*` swallow leftover characters as a path, so URLs like `https://example.com.ñ` and `https://example.abcdef` matched via TLD backtracking. Restrict the path part to start with `/`, `?`, or `#` so no domain-label leftovers can be absorbed.

Fixes #14 