### PR TITLE
fix valid_url?/1 accepting stray digits between TLD and port

### DIFF
--- a/lib/funkspector/utils.ex
+++ b/lib/funkspector/utils.ex
@@ -6,7 +6,7 @@ defmodule Funkspector.Utils do
   and URL validation using a regular expression that supports internationalized domain names.
   """
 
-  @url_regexp ~r/\Ahttp(s?)\:\/\/[a-zñäëïöüáéíóúàèìòùâêîôû0-9\-_]+([\.]{1}[a-zñäëïöüáéíóúàèìòùâêîôû0-9\-]+)*\.[a-z0-9]{2,5}(([0-9]{1,5})?(:(\d{1,5}))?([\/\?#].*)?)?\z/i
+  @url_regexp ~r/\Ahttp(s?)\:\/\/[a-zñäëïöüáéíóúàèìòùâêîôû0-9\-_]+([\.]{1}[a-zñäëïöüáéíóúàèìòùâêîôû0-9\-]+)*\.[a-z0-9]{2,5}((:(\d{1,5}))?([\/\?#].*)?)?\z/i
 
   @doc """
   Converts relative URLs to absolute URLs using the given base URL.

--- a/test/utils_test.exs
+++ b/test/utils_test.exs
@@ -90,6 +90,12 @@ defmodule UtilsTest do
       refute Utils.valid_url?("https://example.abcdef")
     end
 
+    test "returns false when stray digits appear between TLD and port or path" do
+      refute Utils.valid_url?("https://example.com8080")
+      refute Utils.valid_url?("https://example.com8080:443")
+      refute Utils.valid_url?("https://example.com12345/path")
+    end
+
     test "returns false for non-HTTP URLs" do
       refute Utils.valid_url?("ftp://example.com")
       refute Utils.valid_url?("mailto:user@example.com")


### PR DESCRIPTION
The leading ([0-9]{1,5})? group in @url_regexp accepted bare digits glued onto the TLD, so URLs like `https://example.com8080` and `https://example.com12345/path` matched. The group had no purpose — real ports must be preceded by `:`, already covered by (:(\d{1,5}))?.

Fixes #18 