### PR TITLE
Harden v2.0.0: secure-by-default TLS, resource limits, redirect/XXE fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
   lint:
       runs-on: ubuntu-24.04
       steps:
-        - uses: actions/checkout@v2
+        - uses: actions/checkout@v4
 
         - uses: erlef/setup-beam@v1
           with:
@@ -44,7 +44,7 @@ jobs:
           otp-version: ${{ matrix.otp }}
           elixir-version: ${{ matrix.elixir }}
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: |
             deps
@@ -56,4 +56,4 @@ jobs:
       - run: mix deps.get
       - run: mix deps.compile
       - run: mix compile
-      - run: mix test
+      - run: mix test.adapters

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,0 @@
-language: elixir
-elixir:
-  - 1.17.3
-otp_release:
-  - 27.1.2
-sudo: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ Pluggable HTTP adapter. Funkspector no longer hardcodes HTTPoison/hackney; inste
 - **TLS certificates are now verified by default** (both adapters). Pre-2.0 disabled verification (`hackney: [:insecure]`); pass `insecure: true` to restore that for hosts with broken/self-signed certificates. Note that `:basic_auth` credentials are sent over the connection, so the secure default matters.
 - Redirect chains exceeding the 5-hop limit now return `{:error, url, :too_many_redirects}` instead of `{:ok, url, <last 3xx response>}`.
 - A 3xx response with no usable `Location` header now returns an error tuple instead of raising; `Location`/`Content-Encoding` header lookups are case-insensitive across adapters.
-- Error tuples report the original requested URL (not the post-redirect URL), and `:basic_auth` is stripped when a redirect crosses origin.
+- The `page_scrape`/`sitemap_scrape`/`text_sitemap_scrape` error tuples report the original requested URL (not the post-redirect URL); `resolve/2` continues to report the URL that actually failed. `:basic_auth` is stripped when a redirect crosses origin.
 - Passing a non-binary `:contents` now returns `{:error, url, :invalid_contents}` instead of raising.
 
 ### Why

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ Pluggable HTTP adapter. Funkspector no longer hardcodes HTTPoison/hackney; inste
 - `Funkspector.Response` and `Funkspector.Error` — adapter-agnostic structs returned to callers.
 - `:adapter` option on every public call for per-call adapter override.
 - App-wide adapter configuration via `config :funkspector, :http_adapter, …`.
+- `:insecure` option (default `false`) to disable TLS certificate verification per call, honored by both adapters.
+- `:max_body_size` option (default 100 MB) that bounds both the raw response body and gzip decompression; oversized responses return `%Funkspector.Error{reason: :body_too_large}`. Set `:infinity` to disable.
 - Mix aliases: `mix test.httpoison` (run the suite against the HTTPoison adapter) and `mix test.adapters` (run both back-to-back).
 
 ### Changed (breaking)
@@ -21,10 +23,15 @@ Pluggable HTTP adapter. Funkspector no longer hardcodes HTTPoison/hackney; inste
 - Non-2xx HTTP responses surface as `%Funkspector.Response{status_code: integer, headers: list, body: binary}` instead of `%HTTPoison.Response{}`.
 - Default HTTP transport is now Req. Set `config :funkspector, :http_adapter, Funkspector.HTTP.Adapters.HTTPoison` to keep the previous behavior.
 - `:httpoison` and `:hackney` are now `optional: true` deps. Add them to your own `mix.exs` if you select the HTTPoison adapter.
+- **TLS certificates are now verified by default** (both adapters). Pre-2.0 disabled verification (`hackney: [:insecure]`); pass `insecure: true` to restore that for hosts with broken/self-signed certificates. Note that `:basic_auth` credentials are sent over the connection, so the secure default matters.
+- Redirect chains exceeding the 5-hop limit now return `{:error, url, :too_many_redirects}` instead of `{:ok, url, <last 3xx response>}`.
+- A 3xx response with no usable `Location` header now returns an error tuple instead of raising; `Location`/`Content-Encoding` header lookups are case-insensitive across adapters.
+- Error tuples report the original requested URL (not the post-redirect URL), and `:basic_auth` is stripped when a redirect crosses origin.
+- Passing a non-binary `:contents` now returns `{:error, url, :invalid_contents}` instead of raising.
 
 ### Why
 
-Hackney 4.x ships fixes for [CVE-2026-47066..47076](https://github.com/benoitc/hackney/security/advisories) (Alt-Svc parsing, WebSocket framing, SSRF via redirects, CR/LF injection), but HTTPoison 2.3.0 is constrained to `hackney ~> 1.21` and changed body-fetch contracts prevent simply overriding. Req does not depend on hackney and is unaffected.
+hackney 4.0.1 ships fixes for a cluster of 2026 advisories; the two that affect the pinned hackney 1.21 are [CVE-2026-47075](https://nvd.nist.gov/vuln/detail/CVE-2026-47075) (CRLF injection / HTTP request splitting) and [CVE-2026-47076](https://nvd.nist.gov/vuln/detail/CVE-2026-47076) (SSRF via URL normalization). HTTPoison 2.3.0 is constrained to `hackney ~> 1.21` and changed body-fetch contracts prevent simply overriding ([httpoison#501](https://github.com/edgurgel/httpoison/issues/501)). Req does not depend on hackney and is unaffected.
 
 ### Migration
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2016 Jaime Iniesta
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -101,6 +101,30 @@ Use `recv_timeout` to set a custom timeout in milliseconds:
 Funkspector.page_scrape("https://example.com", %{recv_timeout: 5_000})
 ```
 
+> Note: `recv_timeout` is a per-chunk receive timeout, not a bound on total
+> request time.
+
+#### Disabling TLS verification
+
+TLS certificates are verified by default. To scrape a host with a broken,
+self-signed, or expired certificate, opt out explicitly (this disables MITM
+protection for that request, so use it deliberately):
+
+```elixir
+Funkspector.page_scrape("https://self-signed.example.com", %{insecure: true})
+```
+
+#### Limiting the response body size
+
+`max_body_size` (default 100 MB) bounds both the raw response body and gzip
+decompression, protecting against memory exhaustion and decompression bombs
+when scraping untrusted URLs. Oversized responses return
+`%Funkspector.Error{reason: :body_too_large}`. Set `:infinity` to disable:
+
+```elixir
+Funkspector.page_scrape("https://example.com", %{max_body_size: 5_000_000})
+```
+
 #### Loading pre-fetched contents
 
 You can skip the HTTP request if you already have the document contents:
@@ -139,12 +163,16 @@ The `reason` is one of:
 Funkspector 2.0 ships with two HTTP adapters:
 
 - `Funkspector.HTTP.Adapters.Req` (**default**) — backed by
-  [Req](https://hex.pm/packages/req)/Finch/Mint. No `hackney` dependency,
-  so it sidesteps the hackney 4.x CVE upgrade path that's currently blocked
-  by [httpoison#501](https://github.com/edgurgel/httpoison/issues/501).
+  [Req](https://hex.pm/packages/req)/Finch/Mint. No `hackney` dependency, so
+  it is unaffected by the hackney 1.21 issues
+  ([CVE-2026-47075](https://nvd.nist.gov/vuln/detail/CVE-2026-47075),
+  [CVE-2026-47076](https://nvd.nist.gov/vuln/detail/CVE-2026-47076)) whose fix
+  in hackney 4.0.1 is blocked for HTTPoison by
+  [httpoison#501](https://github.com/edgurgel/httpoison/issues/501).
 - `Funkspector.HTTP.Adapters.HTTPoison` — backed by
-  [HTTPoison](https://hex.pm/packages/httpoison)/hackney. Opt-in for users
-  who want to preserve the pre-2.0 transport.
+  [HTTPoison](https://hex.pm/packages/httpoison)/hackney. Opt-in for users who
+  want to preserve the pre-2.0 transport; note it carries the hackney 1.21
+  CVEs above.
 
 ### Switching the default adapter
 
@@ -185,3 +213,23 @@ The error and response structs are normalized across adapters:
 
 The `:reason` atom is unchanged, so most pattern matches require only a
 struct rename.
+
+## Security considerations
+
+Funkspector fetches whatever URL you give it and follows redirects, so when
+you point it at untrusted or user-supplied URLs, keep in mind:
+
+- **No SSRF filtering.** `valid_url?/1` accepts `localhost`, IP-literal hosts
+  (including private ranges like `10.0.0.0/8`, link-local `169.254.169.254`,
+  and IPv6 loopback), and these are reachable both directly and via a redirect
+  from a public URL. Funkspector does not block them — enforce your own
+  allow/deny policy or network-level egress controls before fetching
+  attacker-influenced URLs. Note that input validation alone is insufficient,
+  because a public URL can redirect to an internal one.
+- **TLS is verified by default.** Disable it only deliberately, per call, with
+  `%{insecure: true}`.
+- **Bound the response size** with `max_body_size` (on by default at 100 MB)
+  when scraping untrusted hosts.
+- **`links.http.internal` is not a security boundary** — it is a host-string
+  match against the final fetched host and honors the page's `<base href>`.
+  Re-validate any extracted URL before fetching it.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -156,5 +156,5 @@ Define specific error atoms or structs:
 These MetaInspector features don't apply or have Elixir equivalents:
 
 - **Nokogiri document access** (`parsed`) - Funkspector uses Floki; users can call `Floki.parse_document!/1` on `document.contents` directly.
-- **Faraday middleware** - Funkspector uses HTTPoison/Hackney; middleware patterns differ in Elixir.
+- **Faraday middleware** - Funkspector uses Req (Finch/Mint) by default behind a pluggable HTTP adapter; middleware patterns differ in Elixir.
 - **Lazy evaluation** - MetaInspector defers HTTP requests until data is accessed. Funkspector's functional API (`page_scrape/2` returns everything at once) is more idiomatic in Elixir.

--- a/lib/funkspector.ex
+++ b/lib/funkspector.ex
@@ -44,7 +44,6 @@ defmodule Funkspector do
           | :invalid_url
           | :invalid_contents
           | :too_many_redirects
-          | :body_too_large
 
   @doc """
   Follows redirections for the given URL, returning the final URL and response.
@@ -55,8 +54,8 @@ defmodule Funkspector do
       iex> final_url
       "https://github.com/"
   """
-  @spec resolve(String.t(), map()) ::
-          {:ok, String.t(), Response.t()} | {:error, String.t(), error_reason()}
+  @spec resolve(String.t() | any(), map()) ::
+          {:ok, String.t(), Response.t()} | {:error, String.t() | any(), error_reason()}
   def resolve(url, options \\ %{}) do
     options = Map.merge(default_options(), options)
 
@@ -85,8 +84,8 @@ defmodule Funkspector do
       iex> {:error, "https://notfoundwebsite.com", %Funkspector.Error{reason: :nxdomain}} =
       ...>   Funkspector.page_scrape("https://notfoundwebsite.com")
   """
-  @spec page_scrape(String.t(), map()) ::
-          {:ok, Document.t()} | {:error, String.t(), error_reason()}
+  @spec page_scrape(String.t() | any(), map()) ::
+          {:ok, Document.t()} | {:error, String.t() | any(), error_reason()}
   def page_scrape(url, options \\ %{}) do
     scrape(url, options, &PageScraper.scrape/1)
   end
@@ -109,8 +108,8 @@ defmodule Funkspector do
       iex> hd(document.data.locs)
       "https://rocketvalidator.com/"
   """
-  @spec sitemap_scrape(String.t(), map()) ::
-          {:ok, Document.t()} | {:error, String.t(), error_reason()}
+  @spec sitemap_scrape(String.t() | any(), map()) ::
+          {:ok, Document.t()} | {:error, String.t() | any(), error_reason()}
   def sitemap_scrape(url, options \\ %{}) do
     scrape(url, options, &SitemapScraper.scrape/1)
   end
@@ -133,8 +132,8 @@ defmodule Funkspector do
       iex> hd(document.data.lines)
       "https://rocketvalidator.com/"
   """
-  @spec text_sitemap_scrape(String.t(), map()) ::
-          {:ok, Document.t()} | {:error, String.t(), error_reason()}
+  @spec text_sitemap_scrape(String.t() | any(), map()) ::
+          {:ok, Document.t()} | {:error, String.t() | any(), error_reason()}
   def text_sitemap_scrape(url, options \\ %{}) do
     scrape(url, options, &TextSitemapScraper.scrape/1)
   end

--- a/lib/funkspector.ex
+++ b/lib/funkspector.ex
@@ -32,6 +32,19 @@ defmodule Funkspector do
   """
 
   alias Funkspector.{Resolver, Document, PageScraper, SitemapScraper, TextSitemapScraper}
+  alias Funkspector.{Response, Error}
+
+  @typedoc """
+  Why a `resolve`/`scrape` call failed: a non-2xx `Funkspector.Response`, a
+  transport `Funkspector.Error`, or one of the validation/limit atoms.
+  """
+  @type error_reason ::
+          Response.t()
+          | Error.t()
+          | :invalid_url
+          | :invalid_contents
+          | :too_many_redirects
+          | :body_too_large
 
   @doc """
   Follows redirections for the given URL, returning the final URL and response.
@@ -43,7 +56,7 @@ defmodule Funkspector do
       "https://github.com/"
   """
   @spec resolve(String.t(), map()) ::
-          {:ok, String.t(), map()} | {:error, String.t() | any(), any()}
+          {:ok, String.t(), Response.t()} | {:error, String.t(), error_reason()}
   def resolve(url, options \\ %{}) do
     options = Map.merge(default_options(), options)
 
@@ -73,7 +86,7 @@ defmodule Funkspector do
       ...>   Funkspector.page_scrape("https://notfoundwebsite.com")
   """
   @spec page_scrape(String.t(), map()) ::
-          {:ok, Document.t()} | {:error, String.t() | any(), any()}
+          {:ok, Document.t()} | {:error, String.t(), error_reason()}
   def page_scrape(url, options \\ %{}) do
     scrape(url, options, &PageScraper.scrape/1)
   end
@@ -97,7 +110,7 @@ defmodule Funkspector do
       "https://rocketvalidator.com/"
   """
   @spec sitemap_scrape(String.t(), map()) ::
-          {:ok, Document.t()} | {:error, String.t() | any(), any()}
+          {:ok, Document.t()} | {:error, String.t(), error_reason()}
   def sitemap_scrape(url, options \\ %{}) do
     scrape(url, options, &SitemapScraper.scrape/1)
   end
@@ -121,7 +134,7 @@ defmodule Funkspector do
       "https://rocketvalidator.com/"
   """
   @spec text_sitemap_scrape(String.t(), map()) ::
-          {:ok, Document.t()} | {:error, String.t() | any(), any()}
+          {:ok, Document.t()} | {:error, String.t(), error_reason()}
   def text_sitemap_scrape(url, options \\ %{}) do
     scrape(url, options, &TextSitemapScraper.scrape/1)
   end
@@ -132,16 +145,23 @@ defmodule Funkspector do
 
   defp default_options do
     %{
-      # `hackney: [:insecure]` is honored by the HTTPoison adapter (matches
-      # pre-2.0 behavior). The Req adapter translates `:insecure` into its
-      # own transport options (`verify: :verify_none`) at the boundary so
-      # the same default applies regardless of adapter choice.
-      hackney: [:insecure],
+      # TLS certificate verification is ON by default. Pass `insecure: true`
+      # to disable it for hosts with broken/self-signed certificates; both
+      # adapters honor the flag (see `Funkspector.HTTP.Adapter`).
+      insecure: false,
       timeout: 28_000,
       recv_timeout: 25_000,
-      user_agent: "Funkspector/2.0.0 (+https://hex.pm/packages/funkspector)"
+      # Upper bound on both the raw response body and the gunzipped output, to
+      # bound memory when scraping untrusted URLs (decompression is hard-capped;
+      # the raw body is checked after receipt). Set `:infinity` to disable.
+      max_body_size: 100_000_000,
+      user_agent: "Funkspector/#{version()} (+https://hex.pm/packages/funkspector)"
     }
   end
+
+  # Read from the compiled app spec so the User-Agent tracks the mix.exs
+  # version instead of duplicating it.
+  defp version, do: Application.spec(:funkspector, :vsn) |> to_string()
 
   defp scrape(url, options, scraping_function) do
     options = Map.merge(default_options(), options)
@@ -156,6 +176,7 @@ defmodule Funkspector do
     case options[:contents] do
       nil -> Document.request(url, options)
       contents when is_binary(contents) -> Document.load(url, contents)
+      _ -> {:error, url, :invalid_contents}
     end
   end
 end

--- a/lib/funkspector/document.ex
+++ b/lib/funkspector/document.ex
@@ -15,7 +15,7 @@ defmodule Funkspector.Document do
   defstruct [:url, :contents, :data]
 
   alias __MODULE__
-  alias Funkspector.{Resolver, Response}
+  alias Funkspector.{Resolver, Response, Error}
 
   import Funkspector.Utils, only: [valid_url?: 1]
 
@@ -27,14 +27,18 @@ defmodule Funkspector.Document do
   URL is invalid, the host cannot be resolved, or the response status is not 2xx.
   """
   @spec request(String.t(), map()) ::
-          {:ok, t()} | {:error, String.t() | any(), any()}
+          {:ok, t()}
+          | {:error, String.t(),
+             Response.t() | Error.t() | :invalid_url | :too_many_redirects | :body_too_large}
   def request(url, options \\ %{}) do
     case Resolver.resolve(url, options) do
       {:ok, final_url, response} ->
         handle_response(response, url, final_url)
 
-      {_, url, response} ->
-        {:error, url, response}
+      # Preserve the caller's original URL in the error tuple rather than the
+      # post-redirect URL the resolver failed on.
+      {_, _resolved_url, reason} ->
+        {:error, url, reason}
     end
   end
 

--- a/lib/funkspector/document.ex
+++ b/lib/funkspector/document.ex
@@ -26,10 +26,10 @@ defmodule Funkspector.Document do
   along with the response body and headers. Returns an error tuple if the
   URL is invalid, the host cannot be resolved, or the response status is not 2xx.
   """
-  @spec request(String.t(), map()) ::
+  @spec request(String.t() | any(), map()) ::
           {:ok, t()}
-          | {:error, String.t(),
-             Response.t() | Error.t() | :invalid_url | :too_many_redirects | :body_too_large}
+          | {:error, String.t() | any(),
+             Response.t() | Error.t() | :invalid_url | :too_many_redirects}
   def request(url, options \\ %{}) do
     case Resolver.resolve(url, options) do
       {:ok, final_url, response} ->

--- a/lib/funkspector/http/adapter.ex
+++ b/lib/funkspector/http/adapter.ex
@@ -17,7 +17,8 @@ defmodule Funkspector.HTTP.Adapter do
   Two built-in adapters ship with Funkspector:
 
     * `Funkspector.HTTP.Adapters.Req` (default) — uses Req on top of
-      Finch/Mint, CVE-free since hackney is not involved.
+      Finch/Mint; not exposed to the hackney 1.x CVEs since hackney is not
+      involved.
     * `Funkspector.HTTP.Adapters.HTTPoison` (opt-in) — wraps the
       historical `HTTPoison`/`hackney 1.21` stack.
 

--- a/lib/funkspector/http/adapters/httpoison.ex
+++ b/lib/funkspector/http/adapters/httpoison.ex
@@ -1,113 +1,125 @@
 if Code.ensure_loaded?(HTTPoison) do
-defmodule Funkspector.HTTP.Adapters.HTTPoison do
-  @moduledoc """
-  Opt-in Funkspector HTTP adapter, backed by
-  [HTTPoison](https://hex.pm/packages/httpoison) on top of hackney.
+  defmodule Funkspector.HTTP.Adapters.HTTPoison do
+    @moduledoc """
+    Opt-in Funkspector HTTP adapter, backed by
+    [HTTPoison](https://hex.pm/packages/httpoison) on top of hackney.
 
-  Compiled only when the `:httpoison` dependency is actually present in the
-  consuming project — `httpoison` is declared `optional: true` in
-  `funkspector`'s `mix.exs`, so projects that stick with the default Req
-  adapter do not need to pull it in. When HTTPoison is missing the module
-  is simply not defined; selecting it as the adapter in that case fails
-  with `UndefinedFunctionError` at call time, which is the desired
-  behaviour for an explicit opt-in.
+    Compiled only when the `:httpoison` dependency is actually present in the
+    consuming project — `httpoison` is declared `optional: true` in
+    `funkspector`'s `mix.exs`, so projects that stick with the default Req
+    adapter do not need to pull it in. When HTTPoison is missing the module
+    is simply not defined; selecting it as the adapter in that case fails
+    with `UndefinedFunctionError` at call time, which is the desired
+    behaviour for an explicit opt-in.
 
-  This is the historical Funkspector HTTP path, preserved for users who
-  cannot — or do not want to — move to Req yet. The defaults here match
-  the pre-2.0 behavior:
+    This is the historical Funkspector HTTP path, preserved for users who
+    cannot — or do not want to — move to Req yet. Like the Req adapter, it
+    verifies TLS certificates by default; pass `insecure: true` (folded into
+    hackney's native `:insecure` flag) to opt out. `:user_agent`,
+    `:basic_auth`, `:ssl`, `:timeout`, `:recv_timeout`, and `:max_body_size`
+    are honored.
 
-    * `hackney: [:insecure]` (cert chain verification disabled);
-    * `:user_agent`, `:basic_auth`, `:ssl`, `:timeout`, `:recv_timeout`
-      pass straight through to HTTPoison/hackney.
+    Errors from HTTPoison/hackney are translated to `%Funkspector.Error{}`
+    so the rest of the pipeline does not see adapter-specific structs.
 
-  Errors from HTTPoison/hackney are translated to `%Funkspector.Error{}`
-  so the rest of the pipeline does not see adapter-specific structs.
+    Activate via application config or per-call options:
 
-  Activate via application config or per-call options:
+        config :funkspector, :http_adapter, Funkspector.HTTP.Adapters.HTTPoison
 
-      config :funkspector, :http_adapter, Funkspector.HTTP.Adapters.HTTPoison
+        Funkspector.resolve(url, %{adapter: Funkspector.HTTP.Adapters.HTTPoison})
 
-      Funkspector.resolve(url, %{adapter: Funkspector.HTTP.Adapters.HTTPoison})
+    > #### Security note {: .warning}
+    > hackney 1.21 is affected by
+    > [CVE-2026-47075](https://nvd.nist.gov/vuln/detail/CVE-2026-47075) (CRLF
+    > injection / request splitting) and
+    > [CVE-2026-47076](https://nvd.nist.gov/vuln/detail/CVE-2026-47076) (SSRF
+    > via URL normalization), both fixed in hackney 4.0.1. HTTPoison's
+    > `~> 1.21` constraint cannot reach that fix
+    > ([httpoison#501](https://github.com/edgurgel/httpoison/issues/501)), so
+    > prefer the default Req adapter for new integrations.
+    """
 
-  > #### Security note {: .warning}
-  > hackney 1.21 is still vulnerable to the
-  > CVE-2026-47066..47076 cluster (Alt-Svc parsing, WebSocket framing,
-  > SSRF via redirects, CR/LF injection). Prefer the Req adapter for new
-  > integrations.
-  """
+    @behaviour Funkspector.HTTP.Adapter
 
-  @behaviour Funkspector.HTTP.Adapter
+    alias Funkspector.{Response, Error}
 
-  alias Funkspector.{Response, Error}
+    @impl true
+    def get(url, opts) when is_map(opts) do
+      {headers, request_options} = request_headers_and_options(opts)
 
-  @impl true
-  def get(url, opts) when is_map(opts) do
-    {headers, request_options} = request_headers_and_options(opts)
+      max_body_size = opts[:max_body_size]
 
-    case HTTPoison.get(url, headers, Map.to_list(request_options)) do
-      {:ok, %HTTPoison.Response{status_code: status, headers: response_headers, body: body}} ->
-        {:ok,
-         %Response{
-           status_code: status,
-           headers: response_headers,
-           body: body,
-           request_url: url
-         }}
+      case HTTPoison.get(url, headers, Map.to_list(request_options)) do
+        {:ok, %HTTPoison.Response{status_code: status, headers: response_headers, body: body}} ->
+          build_response(url, status, response_headers, body, max_body_size)
 
-      {:ok, %{status_code: status, headers: response_headers, body: body}} ->
-        {:ok,
-         %Response{
-           status_code: status,
-           headers: response_headers,
-           body: body,
-           request_url: url
-         }}
+        {:ok, %{status_code: status, headers: response_headers, body: body}} ->
+          build_response(url, status, response_headers, body, max_body_size)
 
-      {:ok, %{status_code: status, headers: response_headers}} ->
-        {:ok,
-         %Response{
-           status_code: status,
-           headers: response_headers,
-           body: nil,
-           request_url: url
-         }}
+        {:ok, %{status_code: status, headers: response_headers}} ->
+          build_response(url, status, response_headers, nil, max_body_size)
 
-      {:error, %HTTPoison.Error{reason: reason}} ->
-        {:error, %Error{reason: reason, adapter: __MODULE__}}
+        {:error, %HTTPoison.Error{reason: reason}} ->
+          {:error, %Error{reason: reason, adapter: __MODULE__}}
 
-      {:error, %{reason: reason}} ->
-        {:error, %Error{reason: reason, adapter: __MODULE__}}
+        {:error, %{reason: reason}} ->
+          {:error, %Error{reason: reason, adapter: __MODULE__}}
 
-      {:error, reason} ->
-        {:error, %Error{reason: reason, adapter: __MODULE__}}
+        {:error, reason} ->
+          {:error, %Error{reason: reason, adapter: __MODULE__}}
+      end
+    end
+
+    defp build_response(url, status, headers, body, max_body_size) do
+      if within_limit?(body, max_body_size) do
+        {:ok, %Response{status_code: status, headers: headers, body: body, request_url: url}}
+      else
+        {:error, %Error{reason: :body_too_large, adapter: __MODULE__}}
+      end
+    end
+
+    defp within_limit?(nil, _limit), do: true
+    defp within_limit?(_body, nil), do: true
+    defp within_limit?(_body, :infinity), do: true
+    defp within_limit?(body, limit) when is_integer(limit), do: byte_size(body) <= limit
+
+    defp request_headers_and_options(options) do
+      headers = request_headers(options)
+
+      options =
+        options
+        |> translate_insecure()
+        |> Map.delete(:user_agent)
+        |> Map.delete(:basic_auth)
+        |> Map.delete(:adapter)
+        |> Map.delete(:contents)
+        |> Map.delete(:connect_options)
+        |> Map.delete(:insecure)
+
+      {headers, options}
+    end
+
+    # `insecure: true` disables hackney's certificate verification, mirroring the
+    # Req adapter. It is folded into the `:hackney` option list (hackney's native
+    # `:insecure` flag) so explicit `:hackney` opts the caller passed are kept.
+    defp translate_insecure(%{insecure: true} = options) do
+      hackney = Enum.uniq([:insecure | Map.get(options, :hackney, [])])
+      Map.put(options, :hackney, hackney)
+    end
+
+    defp translate_insecure(options), do: options
+
+    defp request_headers(options) do
+      headers = [{"User-Agent", options[:user_agent]}]
+
+      case options[:basic_auth] do
+        {username, password} ->
+          auth = Base.encode64("#{username}:#{password}")
+          [{"Authorization", "Basic #{auth}"} | headers]
+
+        _ ->
+          headers
+      end
     end
   end
-
-  defp request_headers_and_options(options) do
-    headers = request_headers(options)
-
-    options =
-      options
-      |> Map.delete(:user_agent)
-      |> Map.delete(:basic_auth)
-      |> Map.delete(:adapter)
-      |> Map.delete(:contents)
-      |> Map.delete(:connect_options)
-
-    {headers, options}
-  end
-
-  defp request_headers(options) do
-    headers = [{"User-Agent", options[:user_agent]}]
-
-    case options[:basic_auth] do
-      {username, password} ->
-        auth = Base.encode64("#{username}:#{password}")
-        [{"Authorization", "Basic #{auth}"} | headers]
-
-      _ ->
-        headers
-    end
-  end
-end
 end

--- a/lib/funkspector/http/adapters/httpoison.ex
+++ b/lib/funkspector/http/adapters/httpoison.ex
@@ -95,6 +95,8 @@ if Code.ensure_loaded?(HTTPoison) do
         |> Map.delete(:contents)
         |> Map.delete(:connect_options)
         |> Map.delete(:insecure)
+        # Funkspector-level option, not a hackney/HTTPoison request option.
+        |> Map.delete(:max_body_size)
 
       {headers, options}
     end

--- a/lib/funkspector/http/adapters/req.ex
+++ b/lib/funkspector/http/adapters/req.ex
@@ -3,20 +3,30 @@ defmodule Funkspector.HTTP.Adapters.Req do
   Default Funkspector HTTP adapter, backed by [Req](https://hex.pm/packages/req)
   (Finch/Mint).
 
-  Req does not depend on hackney, so this adapter is the recommended path
-  for new code: it sidesteps the hackney 4.x CVE cluster
-  (CVE-2026-47066..47076) that the legacy `HTTPoison`/`hackney 1.21` stack
-  is still vulnerable to.
+  Req does not depend on hackney, so this adapter is the recommended path for
+  new code: it is unaffected by the hackney 1.x security issues the legacy
+  `HTTPoison`/`hackney 1.21` stack carries — notably
+  [CVE-2026-47075](https://nvd.nist.gov/vuln/detail/CVE-2026-47075) (CRLF
+  injection / request splitting) and
+  [CVE-2026-47076](https://nvd.nist.gov/vuln/detail/CVE-2026-47076) (SSRF via
+  URL normalization). Both are fixed in hackney 4.0.1, which HTTPoison's
+  `~> 1.21` constraint cannot reach
+  ([httpoison#501](https://github.com/edgurgel/httpoison/issues/501)).
 
   Funkspector options are translated to Req options at the boundary:
 
     * `:user_agent`   → `User-Agent` header
     * `:basic_auth`   → `:auth` (basic)
-    * `:timeout`      → `:connect_options[:timeout]`
-    * `:recv_timeout` → `:receive_timeout`
-    * `:ssl`          → `:connect_options[:transport_opts]`
+    * `:timeout`      → `:connect_options[:timeout]` (TCP/TLS connect only)
+    * `:recv_timeout` → `:receive_timeout` (per *chunk*, not a total-time bound)
+    * `:insecure`     → `verify: :verify_none` in the TLS transport opts.
+      Off by default, so certificates are verified (`verify: :verify_peer`).
+    * `:ssl`          → `:connect_options[:transport_opts]` (wins over `:insecure`)
     * `:hackney`      → translated for the well-known `:insecure` flag,
       every other key is silently dropped (and logged at `:debug`).
+    * `:max_body_size` → responses whose body exceeds this many bytes are
+      rejected with `%Funkspector.Error{reason: :body_too_large}` (checked
+      after receipt). `:infinity` (or absence) disables the check.
 
   Redirect following is disabled (`redirect: false`); `Funkspector.Resolver`
   is the sole authority for redirects.
@@ -35,13 +45,7 @@ defmodule Funkspector.HTTP.Adapters.Req do
     try do
       case Req.request(req_opts) do
         {:ok, %Req.Response{status: status, headers: headers, body: body}} ->
-          {:ok,
-           %Response{
-             status_code: status,
-             headers: normalize_headers(headers),
-             body: body_to_binary(body),
-             request_url: url
-           }}
+          build_response(url, status, headers, body_to_binary(body), opts[:max_body_size])
 
         {:error, exception} ->
           {:error, %Error{reason: error_reason(exception), adapter: __MODULE__}}
@@ -51,6 +55,24 @@ defmodule Funkspector.HTTP.Adapters.Req do
         {:error, %Error{reason: error_reason(exception), adapter: __MODULE__}}
     end
   end
+
+  defp build_response(url, status, headers, body, max_body_size) do
+    if within_limit?(body, max_body_size) do
+      {:ok,
+       %Response{
+         status_code: status,
+         headers: normalize_headers(headers),
+         body: body,
+         request_url: url
+       }}
+    else
+      {:error, %Error{reason: :body_too_large, adapter: __MODULE__}}
+    end
+  end
+
+  defp within_limit?(_body, nil), do: true
+  defp within_limit?(_body, :infinity), do: true
+  defp within_limit?(body, limit) when is_integer(limit), do: byte_size(body) <= limit
 
   ##############
   # Translation
@@ -102,17 +124,27 @@ defmodule Funkspector.HTTP.Adapters.Req do
     end
   end
 
+  # Builds the `:transport_opts` for the TLS connection by layering, in
+  # increasing precedence: the `:insecure` flag, the legacy `:hackney`
+  # `:insecure`/`:ssl_options`, and finally an explicit `:ssl` keyword list.
+  # An explicit `:ssl` therefore always wins, and any of the three can turn
+  # verification off. When none are given the result is `nil`, so Req/Mint
+  # keeps its secure `verify: :verify_peer` default.
   defp transport_opts(opts) do
-    from_ssl = opts[:ssl]
-    from_hackney = hackney_transport_opts(opts[:hackney])
-
-    case {from_ssl, from_hackney} do
-      {nil, nil} -> nil
-      {ssl, nil} -> ssl
-      {nil, hackney} -> hackney
-      {ssl, hackney} -> Keyword.merge(hackney, ssl)
+    [
+      insecure_transport_opts(opts[:insecure]),
+      hackney_transport_opts(opts[:hackney]),
+      opts[:ssl]
+    ]
+    |> Enum.reject(&is_nil/1)
+    |> case do
+      [] -> nil
+      layers -> Enum.reduce(layers, [], &Keyword.merge(&2, &1))
     end
   end
+
+  defp insecure_transport_opts(true), do: [verify: :verify_none]
+  defp insecure_transport_opts(_), do: nil
 
   defp hackney_transport_opts(nil), do: nil
 
@@ -173,9 +205,16 @@ defmodule Funkspector.HTTP.Adapters.Req do
   ##############
 
   # Map Req/Mint exceptions onto the `gen_tcp`/`inet` atom contract that
-  # `Funkspector.Resolver` and external callers expect.
+  # `Funkspector.Resolver` and external callers expect. Exceptions without a
+  # transport `:reason` (e.g. a generic runtime error inside Req) are collapsed
+  # to a stable `{:adapter_error, message}` tuple rather than leaking the raw
+  # library struct past the normalized contract.
   defp error_reason(%{reason: reason}) when not is_nil(reason), do: normalize_reason(reason)
-  defp error_reason(exception), do: exception
+
+  defp error_reason(exception) when is_exception(exception),
+    do: {:adapter_error, Exception.message(exception)}
+
+  defp error_reason(other), do: other
 
   defp normalize_reason(:nxdomain), do: :nxdomain
   defp normalize_reason(:timeout), do: :timeout

--- a/lib/funkspector/page_scraper.ex
+++ b/lib/funkspector/page_scraper.ex
@@ -5,6 +5,14 @@ defmodule Funkspector.PageScraper do
   Parses the HTML to find all `<a href>` links, then classifies them as
   internal/external HTTP links or non-HTTP links (mailto, javascript, ftp, etc.).
   Also extracts the `<base href>` and `<link rel="canonical">` values.
+
+  > #### Not a security boundary {: .warning}
+  > `links.http.internal`/`links.http.external` is a host-string comparison
+  > against the final fetched document host, and relative links are resolved
+  > against the page's own `<base href>`. A scraped page can therefore steer
+  > where its relative links point. Re-validate any URL (and apply your own
+  > SSRF/egress controls) before fetching it — do not treat "internal" as
+  > "same-origin and safe".
   """
 
   import Funkspector.Utils
@@ -33,12 +41,20 @@ defmodule Funkspector.PageScraper do
   #####################
 
   defp scraped_data(%Document{url: url, contents: contents, data: data}) do
+    # Parse the HTML once and reuse the tree; a nil body (possible from the
+    # HTTPoison adapter for body-less responses) is treated as empty rather
+    # than crashing `Floki.parse_document!/1`.
+    doc = Floki.parse_document!(contents || "")
+
     urls =
       (data[:urls] || %{})
-      |> Map.put_new(:base, base_href(contents, url) || url)
-      |> Map.put_new(:canonical, canonical_url(contents, url))
+      |> Map.put_new(:base, base_href(doc, url) || url)
 
-    raw_links = raw_links(contents)
+    # The canonical URL is resolved against the (possibly <base href>-derived)
+    # base, consistent with how <a> links are resolved and with the HTML spec.
+    urls = Map.put_new(urls, :canonical, canonical_url(doc, urls.base))
+
+    raw_links = raw_links(doc)
 
     {http_links, non_http_links} =
       raw_links
@@ -61,20 +77,18 @@ defmodule Funkspector.PageScraper do
     |> Map.put_new(:links, links)
   end
 
-  defp canonical_url(html, url) do
-    case html
-         |> Floki.parse_document!()
+  defp canonical_url(doc, base) do
+    case doc
          |> Floki.find("link[rel=canonical]")
          |> Floki.attribute("href")
          |> List.first() do
       nil -> nil
-      canonical_href -> absolutify(canonical_href, url)
+      canonical_href -> absolutify(canonical_href, base)
     end
   end
 
-  defp base_href(html, url) do
-    case html
-         |> Floki.parse_document!()
+  defp base_href(doc, url) do
+    case doc
          |> Floki.find("base")
          |> Floki.attribute("href")
          |> List.first() do
@@ -83,9 +97,8 @@ defmodule Funkspector.PageScraper do
     end
   end
 
-  defp raw_links(html) do
-    html
-    |> Floki.parse_document!()
+  defp raw_links(doc) do
+    doc
     |> Floki.find("a")
     |> Floki.attribute("href")
     |> Enum.map(&String.trim/1)
@@ -100,10 +113,14 @@ defmodule Funkspector.PageScraper do
     Enum.split_with(links, &same_host?(&1, host))
   end
 
+  # Host names are case-insensitive (RFC 3986), so compare them downcased.
   defp same_host?(link, host) do
     case URI.parse(link) do
-      %{host: ^host} -> true
-      _ -> false
+      %{host: link_host} when is_binary(link_host) and is_binary(host) ->
+        String.downcase(link_host) == String.downcase(host)
+
+      _ ->
+        false
     end
   end
 end

--- a/lib/funkspector/resolver.ex
+++ b/lib/funkspector/resolver.ex
@@ -83,7 +83,7 @@ defmodule Funkspector.Resolver do
       {:ok, response} ->
         case deflate(response, max_body_size(options)) do
           {:ok, response} -> dispatch(url, response, max_redirects, options)
-          :too_large -> {:error, url, :body_too_large}
+          :too_large -> {:error, url, %Error{reason: :body_too_large}}
         end
 
       {:error, %Error{reason: reason} = error} ->
@@ -230,7 +230,7 @@ defmodule Funkspector.Resolver do
         if total > limit do
           :too_large
         else
-          safe_inflate(z, [], limit, [acc | output], total)
+          safe_inflate(z, [], limit, [acc, output], total)
         end
 
       {:finished, output} ->
@@ -239,7 +239,7 @@ defmodule Funkspector.Resolver do
         if total > limit do
           :too_large
         else
-          {:ok, IO.iodata_to_binary([acc | output])}
+          {:ok, IO.iodata_to_binary([acc, output])}
         end
     end
   end

--- a/lib/funkspector/resolver.ex
+++ b/lib/funkspector/resolver.ex
@@ -17,27 +17,33 @@ defmodule Funkspector.Resolver do
 
   alias Funkspector.{Response, Error}
 
-  # In case of these errors related with SSL we'll retry setting a TLS version, as per this post:
-  # http://campezzi.ghost.io/httpoison-ssl-connection-closed/
+  # TLS handshake failures we retry by pinning the connection to TLSv1.2 — the
+  # historical workaround for old servers that fail protocol/cipher
+  # negotiation (http://campezzi.ghost.io/httpoison-ssl-connection-closed/).
   #
-  # The match is on the normalized `%Funkspector.Error{}` reason atoms.
-  # Each adapter is responsible for mapping its native error onto these
-  # atoms (`gen_tcp`/`inet` vocabulary).
-  @ssl_retry_reasons [
-    :closed,
-    {:tls_alert, ~c"handshake failure"},
-    {:options, {:sslv3, {:versions, [:"tlsv1.2", :"tlsv1.1", :tlsv1, :sslv3]}}},
-    {:tls_alert,
-     {:handshake_failure,
-      ~c"TLS client: In state hello received SERVER ALERT: Fatal - Handshake Failure\\n"}}
+  # We match the alert *atom* structurally, because each adapter reports a
+  # host- and handshake-state-specific message string (Mint/OTP's
+  # `:ssl.error_alert()` shape `{:tls_alert, {alert, charlist}}`), so an exact
+  # term match would never fire. Certificate-validation alerts
+  # (`:bad_certificate`, `:certificate_expired`, `:unknown_ca`, …) are
+  # deliberately excluded: a version downgrade cannot fix a bad certificate,
+  # and retrying would only mask the rejection.
+  @retryable_tls_alerts [
+    :handshake_failure,
+    :protocol_version,
+    :insufficient_security,
+    :unrecognized_name
   ]
 
   @doc """
   Follows redirections for the given URL and returns the final URL and response.
 
   Validates the URL, then follows up to 5 HTTP redirects (status 301-399).
-  Returns an error for invalid URLs, non-2xx final responses, and HTTP 300
-  (Multiple Choices). On certain SSL errors, retries with TLSv1.2.
+  Returns an error for invalid URLs, non-2xx final responses, HTTP 300
+  (Multiple Choices), a 3xx without a usable `Location` header, and chains
+  that exceed the redirect limit (`:too_many_redirects`). On certain SSL
+  handshake errors, retries once with TLSv1.2 (without consuming the redirect
+  budget). Basic-auth credentials are stripped when a redirect crosses origin.
 
   ## Options
 
@@ -58,10 +64,11 @@ defmodule Funkspector.Resolver do
   """
   @spec resolve(String.t() | any(), map()) ::
           {:ok, String.t(), Response.t()}
-          | {:error, String.t() | any(), Response.t() | Error.t() | :invalid_url}
+          | {:error, String.t() | any(),
+             Response.t() | Error.t() | :invalid_url | :too_many_redirects}
   def resolve(url, options \\ %{}) do
     if valid_url?(url) do
-      resolve_url(url, 5, %{}, options)
+      resolve_url(url, 5, options)
     else
       {:error, url, :invalid_url}
     end
@@ -71,84 +78,176 @@ defmodule Funkspector.Resolver do
   # Private functions #
   #####################
 
-  defp resolve_url(url, max_redirects, response, _options) when max_redirects < 1,
-    do: {:ok, url, response}
-
-  defp resolve_url(url, max_redirects, _response, options) do
+  defp resolve_url(url, max_redirects, options) do
     case adapter(options).get(url, options) do
-      {:ok, response = %Response{status_code: status, headers: headers}}
-      when status in 301..399 ->
-        to = URI.merge(url, location_from(headers)) |> to_string
-        resolve_url(to, max_redirects - 1, deflated(response), options)
-
-      {:ok, response = %Response{status_code: 300}} ->
-        {:error, url, deflated(response)}
-
-      {:ok, response = %Response{status_code: status}} when status < 200 or status >= 400 ->
-        {:error, url, deflated(response)}
-
       {:ok, response} ->
-        {:ok, url, deflated(response)}
+        case deflate(response, max_body_size(options)) do
+          {:ok, response} -> dispatch(url, response, max_redirects, options)
+          :too_large -> {:error, url, :body_too_large}
+        end
 
       {:error, %Error{reason: reason} = error} ->
+        # Retry once with TLSv1.2 on a retryable handshake failure. The retry
+        # does NOT consume the redirect budget; the `is_nil(options[:ssl])`
+        # guard caps it at a single attempt (the merge sets `:ssl`).
         if retry_ssl?(reason) and is_nil(options[:ssl]) do
-          resolve_url(
-            url,
-            max_redirects - 1,
-            error,
-            Map.merge(%{ssl: [versions: [:"tlsv1.2"]]}, options)
-          )
+          resolve_url(url, max_redirects, Map.merge(%{ssl: [versions: [:"tlsv1.2"]]}, options))
         else
           {:error, url, error}
         end
     end
   end
 
-  defp retry_ssl?(reason), do: reason in @ssl_retry_reasons
+  defp dispatch(
+         url,
+         %Response{status_code: status, headers: headers} = response,
+         max_redirects,
+         options
+       )
+       when status in 301..399 do
+    follow_redirect(url, headers, response, max_redirects, options)
+  end
+
+  defp dispatch(url, %Response{status_code: 300} = response, _max_redirects, _options) do
+    {:error, url, response}
+  end
+
+  defp dispatch(url, %Response{status_code: status} = response, _max_redirects, _options)
+       when status < 200 or status >= 400 do
+    {:error, url, response}
+  end
+
+  defp dispatch(url, response, _max_redirects, _options) do
+    {:ok, url, response}
+  end
+
+  # A 3xx with no usable Location header is treated as a terminal response
+  # rather than crashing on `URI.merge(url, nil)`. Once the redirect budget is
+  # exhausted we return an explicit `:too_many_redirects` error instead of an
+  # `:ok` tuple for a URL we never fetched.
+  defp follow_redirect(url, headers, response, max_redirects, options) do
+    case followable_location(url, headers) do
+      nil ->
+        {:error, url, response}
+
+      _to when max_redirects < 1 ->
+        {:error, url, :too_many_redirects}
+
+      to ->
+        resolve_url(to, max_redirects - 1, redirect_options(url, to, options))
+    end
+  end
+
+  defp followable_location(url, headers) do
+    case location_from(headers) do
+      location when is_binary(location) and location != "" ->
+        URI.merge(url, location) |> to_string()
+
+      _ ->
+        nil
+    end
+  end
+
+  # Basic auth must not leak to a different origin, so it is stripped when a
+  # redirect crosses scheme/host/port.
+  defp redirect_options(from_url, to_url, options) do
+    if same_origin?(from_url, to_url) do
+      options
+    else
+      Map.delete(options, :basic_auth)
+    end
+  end
+
+  defp same_origin?(from_url, to_url) do
+    a = URI.parse(from_url)
+    b = URI.parse(to_url)
+
+    downcase(a.scheme) == downcase(b.scheme) and
+      downcase(a.host) == downcase(b.host) and a.port == b.port
+  end
+
+  defp downcase(nil), do: nil
+  defp downcase(string), do: String.downcase(string)
+
+  defp retry_ssl?(:closed), do: true
+  defp retry_ssl?({:tls_alert, {alert, _desc}}), do: alert in @retryable_tls_alerts
+  defp retry_ssl?(_), do: false
 
   defp adapter(options) do
     options[:adapter] ||
       Application.get_env(:funkspector, :http_adapter, Funkspector.HTTP.Adapters.Req)
   end
 
+  # HTTP header field names are case-insensitive, and the two adapters disagree
+  # on casing (Req downcases; HTTPoison preserves the server's), so normalize
+  # before looking anything up.
   defp location_from(headers) do
-    map = Enum.into(headers, %{})
-    map["Location"] || map["location"]
+    downcased_headers(headers)["location"]
   end
 
-  # Deflates the body if it was gzip-compressed. Operates on a normalized
-  # `%Funkspector.Response{}` produced by the adapter, but accepts any map
-  # exposing `:headers` and `:body` so existing tests that pass plain maps
-  # keep working.
-  defp deflated(%Response{} = response) do
-    if gzipped?(response.headers) and is_binary(response.body) do
-      %Response{response | body: :zlib.gunzip(response.body)}
-    else
-      response
-    end
+  defp downcased_headers(headers) when is_list(headers) do
+    Map.new(headers, fn {name, value} -> {String.downcase(name), value} end)
   end
 
-  defp deflated(response) when is_map(response) do
-    headers = Map.get(response, :headers, [])
-    body = Map.get(response, :body)
+  defp downcased_headers(_), do: %{}
 
+  # Decompresses a gzip-encoded body, bounded by `limit` so a small "zip bomb"
+  # cannot expand to gigabytes. Returns `{:ok, response}` (body possibly
+  # inflated) or `:too_large` when the decompressed output would exceed `limit`.
+  defp deflate(%Response{headers: headers, body: body} = response, limit) do
     if gzipped?(headers) and is_binary(body) do
-      Map.put(response, :body, :zlib.gunzip(body))
+      case gunzip_within_limit(body, limit) do
+        {:ok, inflated} -> {:ok, %Response{response | body: inflated}}
+        :too_large -> :too_large
+      end
     else
-      response
+      {:ok, response}
     end
   end
 
-  defp deflated(other), do: other
+  defp deflate(response, _limit), do: {:ok, response}
+
+  defp gunzip_within_limit(body, :infinity), do: {:ok, :zlib.gunzip(body)}
+
+  defp gunzip_within_limit(body, limit) when is_integer(limit) do
+    z = :zlib.open()
+
+    try do
+      :zlib.inflateInit(z, 31)
+      safe_inflate(z, body, limit, [], 0)
+    after
+      :zlib.close(z)
+    end
+  end
+
+  # Streams the decompressed output in zlib-bounded chunks (via `safeInflate`)
+  # so we never materialize more than `limit` bytes before aborting.
+  defp safe_inflate(z, input, limit, acc, total) do
+    case :zlib.safeInflate(z, input) do
+      {:continue, output} ->
+        total = total + IO.iodata_length(output)
+
+        if total > limit do
+          :too_large
+        else
+          safe_inflate(z, [], limit, [acc | output], total)
+        end
+
+      {:finished, output} ->
+        total = total + IO.iodata_length(output)
+
+        if total > limit do
+          :too_large
+        else
+          {:ok, IO.iodata_to_binary([acc | output])}
+        end
+    end
+  end
+
+  defp max_body_size(options), do: options[:max_body_size] || :infinity
 
   defp gzipped?(headers) when is_list(headers) do
-    Enum.any?(headers, fn
-      {"Content-Encoding", "gzip"} -> true
-      {"Content-Encoding", "x-gzip"} -> true
-      {"content-encoding", "gzip"} -> true
-      {"content-encoding", "x-gzip"} -> true
-      _ -> false
-    end)
+    downcased_headers(headers)["content-encoding"] in ["gzip", "x-gzip"]
   end
 
   defp gzipped?(_), do: false

--- a/lib/funkspector/sitemap_scraper.ex
+++ b/lib/funkspector/sitemap_scraper.ex
@@ -36,9 +36,14 @@ defmodule Funkspector.SitemapScraper do
   end
 
   defp raw_locs(xml) do
+    # `dtd: :none` makes SweetXml/xmerl refuse all DTD and entity declarations,
+    # so an attacker-controlled sitemap cannot trigger XXE (external entity /
+    # file read), entity-expansion DoS ("billion laughs"), or an external-DTD
+    # fetch — independent of the consumer's OTP/xmerl version. The catch keeps a
+    # malformed (or DTD-bearing) sitemap returning `[]` rather than crashing.
     try do
       xml
-      |> parse(quiet: true)
+      |> parse(quiet: true, dtd: :none)
       |> xpath(~x"//url/loc/text()"l)
       |> Enum.uniq()
       |> Enum.map(&to_string/1)

--- a/lib/funkspector/utils.ex
+++ b/lib/funkspector/utils.ex
@@ -56,6 +56,12 @@ defmodule Funkspector.Utils do
   rejected, because the IANA list stores those in punycode form and we do
   not ship a punycode encoder.
 
+  This is a syntax/TLD check, **not** an SSRF guard: `localhost`, IP-literal
+  hosts (including private and link-local addresses), and embedded `userinfo`
+  (`http://user:pass@host`) are all considered valid. Apply your own
+  allow/deny policy before fetching untrusted URLs (see the README's
+  "Security considerations").
+
   ## Examples
 
       iex> Funkspector.Utils.valid_url?("https://example.com")

--- a/test/document_test.exs
+++ b/test/document_test.exs
@@ -84,6 +84,23 @@ defmodule Funkspector.DocumentTest do
         assert document.data.urls.original == "http://example.com/redirect/1"
       end
     end
+
+    test "returns the original URL (not the redirected URL) on a non-2xx after redirect" do
+      with_mock @adapter,
+        get: fn url, _opts ->
+          case url do
+            "http://example.com/start" ->
+              redirection_response("Location", "http://example.com/gone")
+
+            "http://example.com/gone" ->
+              unsuccessful_response(404)
+          end
+        end do
+        {:error, original_url, response} = Document.request("http://example.com/start")
+        assert original_url == "http://example.com/start"
+        assert response.status_code == 404
+      end
+    end
   end
 
   describe "load" do

--- a/test/funkspector_test.exs
+++ b/test/funkspector_test.exs
@@ -199,6 +199,11 @@ defmodule FunkspectorTest do
         assert Funkspector.page_scrape(url, %{contents: @html_doc}) == {:error, url, :invalid_url}
       end
     end
+
+    test "returns an error for non-binary contents instead of crashing" do
+      assert Funkspector.page_scrape("https://example.com", %{contents: 123}) ==
+               {:error, "https://example.com", :invalid_contents}
+    end
   end
 
   describe "sitemap_scrape" do

--- a/test/http/adapters/httpoison_test.exs
+++ b/test/http/adapters/httpoison_test.exs
@@ -79,5 +79,11 @@ defmodule Funkspector.HTTP.Adapters.HTTPoisonTest do
                  HTTPoisonAdapter.get("https://example.com", %{max_body_size: 100})
       end
     end
+
+    test "does not forward the funkspector-level :max_body_size option to HTTPoison" do
+      request_options = captured_request_options("https://example.com", %{max_body_size: 100})
+
+      refute Keyword.has_key?(request_options, :max_body_size)
+    end
   end
 end

--- a/test/http/adapters/httpoison_test.exs
+++ b/test/http/adapters/httpoison_test.exs
@@ -1,0 +1,83 @@
+defmodule Funkspector.HTTP.Adapters.HTTPoisonTest do
+  use ExUnit.Case
+
+  import Mock
+
+  alias Funkspector.HTTP.Adapters.HTTPoison, as: HTTPoisonAdapter
+
+  # Captures the request options the adapter passes to `HTTPoison.get/3` by
+  # mocking the underlying client, so we can assert on the option translation
+  # without hitting the network.
+  defp captured_request_options(url, opts) do
+    test_pid = self()
+
+    with_mock HTTPoison,
+      get: fn _url, _headers, request_options ->
+        send(test_pid, {:httpoison_options, request_options})
+        {:ok, %HTTPoison.Response{status_code: 200, headers: [], body: ""}}
+      end do
+      HTTPoisonAdapter.get(url, opts)
+
+      receive do
+        {:httpoison_options, request_options} -> request_options
+      after
+        0 -> flunk("HTTPoison.get/3 was not called")
+      end
+    end
+  end
+
+  describe "TLS verification" do
+    test "does not disable verification by default" do
+      request_options = captured_request_options("https://example.com", %{})
+
+      refute :insecure in Keyword.get(request_options, :hackney, [])
+    end
+
+    test "disables verification via hackney: [:insecure] when insecure: true" do
+      request_options = captured_request_options("https://example.com", %{insecure: true})
+
+      assert :insecure in Keyword.get(request_options, :hackney, [])
+    end
+
+    test "merges insecure: true into existing hackney options" do
+      request_options =
+        captured_request_options("https://example.com", %{
+          insecure: true,
+          hackney: [pool: :default]
+        })
+
+      hackney = Keyword.get(request_options, :hackney, [])
+      assert :insecure in hackney
+      assert hackney[:pool] == :default
+    end
+
+    test "never forwards the raw :insecure key to HTTPoison" do
+      request_options = captured_request_options("https://example.com", %{insecure: true})
+
+      refute Keyword.has_key?(request_options, :insecure)
+    end
+  end
+
+  describe "response body size" do
+    test "rejects a body larger than max_body_size" do
+      with_mock HTTPoison,
+        get: fn _url, _headers, _opts ->
+          {:ok,
+           %HTTPoison.Response{status_code: 200, headers: [], body: String.duplicate("a", 1000)}}
+        end do
+        assert {:error, %Funkspector.Error{reason: :body_too_large}} =
+                 HTTPoisonAdapter.get("https://example.com", %{max_body_size: 100})
+      end
+    end
+
+    test "allows a body within max_body_size" do
+      with_mock HTTPoison,
+        get: fn _url, _headers, _opts ->
+          {:ok, %HTTPoison.Response{status_code: 200, headers: [], body: "small"}}
+        end do
+        assert {:ok, %Funkspector.Response{status_code: 200}} =
+                 HTTPoisonAdapter.get("https://example.com", %{max_body_size: 100})
+      end
+    end
+  end
+end

--- a/test/http/adapters/req_test.exs
+++ b/test/http/adapters/req_test.exs
@@ -1,0 +1,96 @@
+defmodule Funkspector.HTTP.Adapters.ReqTest do
+  use ExUnit.Case
+
+  import Mock
+
+  alias Funkspector.HTTP.Adapters.Req, as: ReqAdapter
+
+  # Captures the keyword list the adapter passes to `Req.request/1` by mocking
+  # the underlying client, so we can assert on the option translation without
+  # hitting the network.
+  defp captured_req_options(url, opts) do
+    test_pid = self()
+
+    with_mock Req,
+      request: fn req_opts ->
+        send(test_pid, {:req_opts, req_opts})
+        {:ok, %Req.Response{status: 200, headers: %{}, body: ""}}
+      end do
+      ReqAdapter.get(url, opts)
+
+      receive do
+        {:req_opts, req_opts} -> req_opts
+      after
+        0 -> flunk("Req.request/1 was not called")
+      end
+    end
+  end
+
+  defp transport_opts(req_opts) do
+    req_opts
+    |> Keyword.get(:connect_options, [])
+    |> Keyword.get(:transport_opts, [])
+  end
+
+  describe "TLS verification" do
+    test "verifies certificates by default (no verify_none)" do
+      req_opts = captured_req_options("https://example.com", %{})
+
+      refute transport_opts(req_opts)[:verify] == :verify_none
+    end
+
+    test "disables certificate verification when insecure: true" do
+      req_opts = captured_req_options("https://example.com", %{insecure: true})
+
+      assert transport_opts(req_opts)[:verify] == :verify_none
+    end
+
+    test "still honors the legacy hackney: [:insecure] flag" do
+      req_opts = captured_req_options("https://example.com", %{hackney: [:insecure]})
+
+      assert transport_opts(req_opts)[:verify] == :verify_none
+    end
+
+    test "still honors an explicit ssl: [verify: :verify_none]" do
+      req_opts = captured_req_options("https://example.com", %{ssl: [verify: :verify_none]})
+
+      assert transport_opts(req_opts)[:verify] == :verify_none
+    end
+  end
+
+  describe "response body size" do
+    test "rejects a body larger than max_body_size" do
+      with_mock Req,
+        request: fn _ ->
+          {:ok, %Req.Response{status: 200, headers: %{}, body: String.duplicate("a", 1000)}}
+        end do
+        assert {:error, %Funkspector.Error{reason: :body_too_large}} =
+                 ReqAdapter.get("https://example.com", %{max_body_size: 100})
+      end
+    end
+
+    test "allows a body within max_body_size" do
+      with_mock Req,
+        request: fn _ -> {:ok, %Req.Response{status: 200, headers: %{}, body: "small"}} end do
+        assert {:ok, %Funkspector.Response{status_code: 200}} =
+                 ReqAdapter.get("https://example.com", %{max_body_size: 100})
+      end
+    end
+  end
+
+  describe "error mapping" do
+    test "passes a transport reason atom through unchanged" do
+      with_mock Req, request: fn _ -> {:error, %Req.TransportError{reason: :nxdomain}} end do
+        assert {:error, %Funkspector.Error{reason: :nxdomain}} =
+                 ReqAdapter.get("https://example.com", %{})
+      end
+    end
+
+    test "maps a reason-less exception to a stable {:adapter_error, _} value" do
+      with_mock Req, request: fn _ -> {:error, %RuntimeError{message: "boom"}} end do
+        assert {:error, %Funkspector.Error{reason: {:adapter_error, "boom"}}} =
+                 ReqAdapter.get("https://example.com", %{})
+      end
+    end
+  end
+end

--- a/test/integration/resolver_integration_test.exs
+++ b/test/integration/resolver_integration_test.exs
@@ -36,8 +36,8 @@ defmodule Funkspector.ResolverIntegrationTest do
       assert {:ok, final_url, %{status_code: 200}} =
                with_transient_retry(fn -> Funkspector.resolve(httpbin_redirect(3)) end)
 
-      # /redirect/N terminates at /get on httpbin.org.
-      assert final_url =~ "httpbin.org/get"
+      # /redirect/N terminates at /get on the httpbin host.
+      assert final_url =~ "/get"
     end
 
     test "follows a relative redirect chain" do
@@ -46,28 +46,26 @@ defmodule Funkspector.ResolverIntegrationTest do
                  Funkspector.resolve(httpbin_relative_redirect(2))
                end)
 
-      assert final_url =~ "httpbin.org/get"
+      assert final_url =~ "/get"
     end
 
     test "follows a cross-host redirect" do
+      # example.com is a different host from the httpbin host, exercising the
+      # cross-origin redirect path. (httpbingo's /redirect-to only allows a
+      # small destination allowlist, of which example.com is a member.)
       assert {:ok, final_url, %{status_code: 200}} =
                with_transient_retry(fn ->
-                 Funkspector.resolve(httpbin_redirect_to("https://hex.pm/"))
+                 Funkspector.resolve(httpbin_redirect_to("https://example.com/"))
                end)
 
-      assert final_url == "https://hex.pm/"
+      assert final_url == "https://example.com/"
     end
 
-    test "stops following redirects after the max of 5 hops" do
-      # /redirect/10 would need 10 hops; the resolver caps at 5 and returns
-      # the URL it was about to fetch next (see Funkspector.Resolver.resolve_url/4
-      # base case at resolver.ex:66).
-      assert {:ok, final_url, _response} =
+    test "returns a too_many_redirects error past the max of 5 hops" do
+      # /redirect/10 needs 10 hops; the resolver caps at 5 and returns an
+      # explicit error tuple rather than a partially-followed chain.
+      assert {:error, _url, :too_many_redirects} =
                with_transient_retry(fn -> Funkspector.resolve(httpbin_redirect(10)) end)
-
-      assert final_url =~ "httpbin.org/"
-      # We did not reach the terminal /get endpoint.
-      refute final_url =~ "/get"
     end
   end
 

--- a/test/integration/tls_integration_test.exs
+++ b/test/integration/tls_integration_test.exs
@@ -2,12 +2,12 @@ defmodule Funkspector.TLSIntegrationTest do
   @moduledoc """
   TLS-specific behaviors against real hosts.
 
-  These are the tests most likely to detect regressions from the hackney
-  upgrade. Funkspector defaults to `hackney: [:insecure]` (see
-  `Funkspector` default_options at `lib/funkspector.ex:117`), which means
-  cert chain verification is disabled. The badssl.com hosts below are
-  precisely the cases that would fail if that default ever silently
-  flipped — exactly the kind of breakage hackney issue #501 produced.
+  Since v2.0.0 Funkspector verifies TLS certificates by default (see
+  `Funkspector` `default_options/0`). The badssl.com hosts below — self
+  signed, expired, and wrong-host certificates — must therefore be
+  *rejected* by default, and only accepted when the caller explicitly opts
+  out with `%{insecure: true}`. These are the tests most likely to detect a
+  regression that silently re-disables verification.
   """
 
   use ExUnit.Case, async: true
@@ -22,19 +22,34 @@ defmodule Funkspector.TLSIntegrationTest do
              with_transient_retry(fn -> Funkspector.resolve(httpbin_root()) end)
   end
 
-  test "accepts a self-signed certificate (verify_none default)" do
+  test "rejects a self-signed certificate by default" do
     url = badssl_self_signed()
-    assert {:ok, ^url, %{status_code: 200}} = Funkspector.resolve(url)
+    assert {:error, ^url, _reason} = Funkspector.resolve(url)
   end
 
-  test "accepts an expired certificate (verify_none default)" do
+  test "rejects an expired certificate by default" do
     url = badssl_expired()
-    assert {:ok, ^url, %{status_code: 200}} = Funkspector.resolve(url)
+    assert {:error, ^url, _reason} = Funkspector.resolve(url)
   end
 
-  test "accepts a certificate whose CN does not match the host (verify_none default)" do
+  test "rejects a certificate whose CN does not match the host by default" do
     url = badssl_wrong_host()
-    assert {:ok, ^url, %{status_code: 200}} = Funkspector.resolve(url)
+    assert {:error, ^url, _reason} = Funkspector.resolve(url)
+  end
+
+  test "accepts a self-signed certificate when insecure: true" do
+    url = badssl_self_signed()
+    assert {:ok, ^url, %{status_code: 200}} = Funkspector.resolve(url, %{insecure: true})
+  end
+
+  test "accepts an expired certificate when insecure: true" do
+    url = badssl_expired()
+    assert {:ok, ^url, %{status_code: 200}} = Funkspector.resolve(url, %{insecure: true})
+  end
+
+  test "accepts a wrong-host certificate when insecure: true" do
+    url = badssl_wrong_host()
+    assert {:ok, ^url, %{status_code: 200}} = Funkspector.resolve(url, %{insecure: true})
   end
 
   test "honors an explicit :ssl override (same code path the SSL retry uses)" do

--- a/test/page_scraper_test.exs
+++ b/test/page_scraper_test.exs
@@ -360,4 +360,36 @@ defmodule PageScraperTest do
     assert data.urls.base == "https://example.com/base/"
     assert data.links.http.internal == ["https://example.com/base/page"]
   end
+
+  test "classifies same-host links case-insensitively" do
+    html = ~s(<html><body><a href="http://EXAMPLE.COM/upper">Upper</a></body></html>)
+    {:ok, document} = Document.load("https://example.com/page", html)
+    {:ok, %Document{data: data}} = PageScraper.scrape(document)
+
+    assert data.links.http.internal == ["http://EXAMPLE.COM/upper"]
+    assert data.links.http.external == []
+  end
+
+  test "resolves a relative canonical URL against the base href" do
+    html =
+      ~s(<html><head><base href="https://example.com/base/">) <>
+        ~s(<link rel="canonical" href="rel-canonical"></head><body></body></html>)
+
+    {:ok, document} = Document.load("https://example.com/dir/page", html)
+    {:ok, %Document{data: data}} = PageScraper.scrape(document)
+
+    assert data.urls.canonical == "https://example.com/base/rel-canonical"
+  end
+
+  test "does not crash on a document with nil contents" do
+    document = %Document{
+      url: "https://example.com/page",
+      contents: nil,
+      data: %{urls: %{parsed: URI.parse("https://example.com/page") |> Map.from_struct()}}
+    }
+
+    assert {:ok, %Document{data: data}} = PageScraper.scrape(document)
+    assert data.links.raw == []
+    assert data.links.http.internal == []
+  end
 end

--- a/test/resolver_test.exs
+++ b/test/resolver_test.exs
@@ -133,7 +133,7 @@ defmodule Funkspector.ResolverTest do
 
   test "aborts gzip decompression that would exceed max_body_size" do
     with_mock @adapter, get: fn _url, _opts -> gzip_response() end do
-      assert {:error, "https://example.com/", :body_too_large} =
+      assert {:error, "https://example.com/", %Error{reason: :body_too_large}} =
                resolve("https://example.com/", %{max_body_size: 10})
     end
   end

--- a/test/resolver_test.exs
+++ b/test/resolver_test.exs
@@ -131,6 +131,13 @@ defmodule Funkspector.ResolverTest do
     end
   end
 
+  test "aborts gzip decompression that would exceed max_body_size" do
+    with_mock @adapter, get: fn _url, _opts -> gzip_response() end do
+      assert {:error, "https://example.com/", :body_too_large} =
+               resolve("https://example.com/", %{max_body_size: 10})
+    end
+  end
+
   test "retries with TLSv1.2 on SSL closed error" do
     call_count = :counters.new(1, [:atomics])
 
@@ -196,6 +203,135 @@ defmodule Funkspector.ResolverTest do
     with_mock @adapter,
       get: fn _url, _opts -> {:ok, %Response{status_code: 100, headers: [], body: ""}} end do
       {:error, "https://example.com/", _} = resolve("https://example.com/")
+    end
+  end
+
+  test "returns an error tuple for a 3xx response without a Location header" do
+    with_mock @adapter,
+      get: fn _url, _opts ->
+        {:ok, %Response{status_code: 301, headers: [{"Content-Type", "text/html"}], body: ""}}
+      end do
+      assert {:error, "http://example.com/", %Response{status_code: 301}} =
+               resolve("http://example.com/")
+    end
+  end
+
+  test "returns an error tuple for a 304 with no Location instead of crashing" do
+    with_mock @adapter,
+      get: fn _url, _opts -> {:ok, %Response{status_code: 304, headers: [], body: ""}} end do
+      assert {:error, "http://example.com/", %Response{status_code: 304}} =
+               resolve("http://example.com/")
+    end
+  end
+
+  test "follows redirects whose Location header uses non-standard casing" do
+    with_mock @adapter,
+      get: fn url, _opts ->
+        case url do
+          "http://example.com/1" ->
+            redirection_response("LOCATION", "http://example.com/2")
+
+          "http://example.com/2" ->
+            successful_response()
+        end
+      end do
+      {:ok, "http://example.com/2", _} = resolve("http://example.com/1")
+    end
+  end
+
+  test "returns a too_many_redirects error on an endless redirect chain" do
+    with_mock @adapter, get: fn url, _opts -> redirection_response("Location", url <> "x") end do
+      assert {:error, _url, :too_many_redirects} = resolve("http://example.com/")
+    end
+  end
+
+  test "fetches the final resource at the redirect limit" do
+    with_mock @adapter, get: fn url, _opts -> long_redirect_chain(url) end do
+      assert {:ok, "http://example.com/chain/6", %Response{status_code: 200}} =
+               resolve("http://example.com/chain/1")
+    end
+  end
+
+  test "strips basic_auth when a redirect crosses origin" do
+    test_pid = self()
+
+    with_mock @adapter,
+      get: fn url, opts ->
+        send(test_pid, {:got, url, opts[:basic_auth]})
+
+        case url do
+          "http://a.example.com/" -> redirection_response("Location", "http://b.example.com/")
+          "http://b.example.com/" -> successful_response()
+        end
+      end do
+      {:ok, "http://b.example.com/", _} =
+        resolve("http://a.example.com/", %{basic_auth: {"user", "pass"}})
+
+      assert_received {:got, "http://a.example.com/", {"user", "pass"}}
+      assert_received {:got, "http://b.example.com/", nil}
+    end
+  end
+
+  test "keeps basic_auth across a same-origin redirect" do
+    test_pid = self()
+
+    with_mock @adapter,
+      get: fn url, opts ->
+        send(test_pid, {:got, url, opts[:basic_auth]})
+
+        case url do
+          "http://example.com/1" -> redirection_response("Location", "http://example.com/2")
+          "http://example.com/2" -> successful_response()
+        end
+      end do
+      {:ok, "http://example.com/2", _} =
+        resolve("http://example.com/1", %{basic_auth: {"user", "pass"}})
+
+      assert_received {:got, "http://example.com/1", {"user", "pass"}}
+      assert_received {:got, "http://example.com/2", {"user", "pass"}}
+    end
+  end
+
+  test "retries with TLSv1.2 on a realistic Mint handshake_failure alert" do
+    call_count = :counters.new(1, [:atomics])
+
+    with_mock @adapter,
+      get: fn _url, opts ->
+        :counters.add(call_count, 1, 1)
+
+        if :counters.get(call_count, 1) == 1 do
+          {:error,
+           %Error{
+             reason:
+               {:tls_alert,
+                {:handshake_failure,
+                 ~c"TLS client: In state wait_sh received SERVER ALERT: Fatal - Handshake Failure"}},
+             adapter: @adapter
+           }}
+        else
+          assert opts[:ssl] == [versions: [:"tlsv1.2"]]
+          successful_response()
+        end
+      end do
+      {:ok, "https://example.com/", _} = resolve("https://example.com/")
+      assert :counters.get(call_count, 1) == 2
+    end
+  end
+
+  test "does not retry on a certificate-validation TLS alert" do
+    call_count = :counters.new(1, [:atomics])
+
+    with_mock @adapter,
+      get: fn _url, _opts ->
+        :counters.add(call_count, 1, 1)
+
+        {:error,
+         %Error{reason: {:tls_alert, {:bad_certificate, ~c"bad cert"}}, adapter: @adapter}}
+      end do
+      assert {:error, "https://example.com/", %Error{reason: {:tls_alert, {:bad_certificate, _}}}} =
+               resolve("https://example.com/")
+
+      assert :counters.get(call_count, 1) == 1
     end
   end
 

--- a/test/sitemap_scraper_test.exs
+++ b/test/sitemap_scraper_test.exs
@@ -133,4 +133,37 @@ defmodule SitemapScraperTest do
 
     refute "https://example.com/commented-out-should-not-be-included" in data.locs
   end
+
+  test "does not expand XML entities in an untrusted sitemap" do
+    xml = """
+    <?xml version="1.0"?>
+    <!DOCTYPE urlset [<!ENTITY x "expanded">]>
+    <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+      <url><loc>/&x;</loc></url>
+    </urlset>
+    """
+
+    {:ok, document} = Document.load("https://example.com/sitemap.xml", xml)
+    {:ok, %Document{data: data}} = SitemapScraper.scrape(document)
+
+    # The entity must never be expanded into a loc, regardless of the OTP/xmerl
+    # version the consumer runs.
+    assert data.locs == []
+    refute Enum.any?(data.locs, &String.contains?(&1, "expanded"))
+  end
+
+  test "does not fetch an external DTD referenced by an untrusted sitemap" do
+    xml = """
+    <?xml version="1.0"?>
+    <!DOCTYPE urlset SYSTEM "http://127.0.0.1:9/evil.dtd">
+    <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+      <url><loc>/page</loc></url>
+    </urlset>
+    """
+
+    {:ok, document} = Document.load("https://example.com/sitemap.xml", xml)
+    {:ok, %Document{data: data}} = SitemapScraper.scrape(document)
+
+    assert is_list(data.locs)
+  end
 end

--- a/test/support/integration_urls.exs
+++ b/test/support/integration_urls.exs
@@ -3,17 +3,22 @@ defmodule FunkspectorTest.IntegrationUrls do
   Stable URL helpers for the integration test suite.
 
   Centralizing every external host in one module keeps the integration
-  tests resilient to upstream outages: if `httpbin.org` becomes flaky we
-  swap `@httpbin_base` to `httpbingo.org` (or self-hosted equivalent) in
-  one place and every test follows. The same applies to `badssl.com` and
-  to the handful of production sites we exercise.
+  tests resilient to upstream outages: if the httpbin host becomes flaky
+  we swap `@httpbin_base` in one place and every test follows. We default
+  to `httpbingo.org` (the actively-maintained go-httpbin reimplementation);
+  `httpbin.io` and `httpbin.org` are drop-in alternatives. The same applies
+  to `badssl.com` and to the handful of production sites we exercise.
 
   Functions are preferred over module attributes so call sites read as
   intent (`httpbin_status(404)`) and so we keep the freedom to compose
   URL parameters later without rippling through every test file.
+
+  Assertions should reference the helpers (or host-neutral fragments like
+  `"/get"`) rather than a literal host, so swapping `@httpbin_base` never
+  breaks a test.
   """
 
-  @httpbin_base "https://httpbin.org"
+  @httpbin_base "https://httpbingo.org"
   @badssl_base "badssl.com"
 
   ##############

--- a/test/support/mocked_connections.exs
+++ b/test/support/mocked_connections.exs
@@ -113,9 +113,15 @@ defmodule FunkspectorTest.MockedConnections do
   end
 
   def ssl_handshake_error() do
+    # The real shape Mint/OTP produce for a handshake failure: a nested
+    # {:tls_alert, {alert_atom, message_charlist}} tuple, not the flat
+    # {:tls_alert, charlist} that hackney once emitted.
     {:error,
      %Error{
-       reason: {:tls_alert, ~c"handshake failure"},
+       reason:
+         {:tls_alert,
+          {:handshake_failure,
+           ~c"TLS client: In state wait_sh received SERVER ALERT: Fatal - Handshake Failure"}},
        adapter: current_adapter()
      }}
   end


### PR DESCRIPTION
Pre-release security & code review hardening for v2.0.0, across both HTTP adapters. All changes are covered by unit tests (Req + HTTPoison) and verified against live hosts; `mix test.adapters` and `mix test --include integration` both pass with 0 failures.

## Transport / TLS
- **Verify TLS certificates by default** (both adapters). Pre-2.0 shipped `hackney: [:insecure]`, which disabled verification on every HTTPS request. Added an explicit `insecure: true` opt-in for hosts with broken/self-signed certs.
- Strip `basic_auth` when a redirect crosses origin (credentials no longer leak to redirect targets).
- Match TLS-retry alerts structurally (real Mint `{:tls_alert, {alert, _}}` shape) and decouple the retry from the redirect budget; replaced the fabricated handshake mock.

## Resource limits
- Bounded gzip decompression via streaming `safeInflate` (real zip-bomb fix) plus a configurable `max_body_size` (default 100 MB, `:infinity` to disable) in both adapters → `%Funkspector.Error{reason: :body_too_large}`.

## Resolver / API contract
- A 3xx with no usable `Location` now returns an error tuple instead of raising `FunctionClauseError`; `Location`/`Content-Encoding` lookups are case-insensitive.
- Redirect-limit exhaustion returns `{:error, url, :too_many_redirects}` instead of `{:ok, url, <last 3xx>}`.
- Error tuples preserve the original requested URL; non-binary `:contents` → `:invalid_contents`; tightened public `@spec`s; stable `{:adapter_error, msg}` reason for reason-less exceptions.

## Scrapers
- `SitemapScraper` parses with `dtd: :none` — OTP-version-independent hardening against XXE, billion-laughs, and external-DTD fetch on attacker-controlled sitemaps.
- `PageScraper` parses once, tolerates a nil body, resolves `<link rel=canonical>` against `<base href>`, and compares hosts case-insensitively.

## Docs / hygiene
- Corrected CVE attribution to the two advisories that actually affect hackney 1.21 — [CVE-2026-47075](https://nvd.nist.gov/vuln/detail/CVE-2026-47075) (CRLF) and [CVE-2026-47076](https://nvd.nist.gov/vuln/detail/CVE-2026-47076) (SSRF) — with NVD links; dropped the overstated "Alt-Svc/WebSocket/cluster" and "CVE-free" wording.
- Added `LICENSE` (was declared MIT but missing from the tarball); documented `insecure`/`max_body_size` and the SSRF posture; UA version now derived from the app spec; removed stale `.travis.yml`; bumped CI actions and made CI run `mix test.adapters`.

## Notes for review
- `max_body_size` default 100 MB is a new (generous) default; `:infinity` disables.
- A total-request-time bound is documented rather than coded — Req 0.5 doesn't forward Finch's `request_timeout` and raises on the unknown option.
- Integration host moved to `httpbingo.org` with host-agnostic assertions.
